### PR TITLE
Implements Slugy functions for schema modules

### DIFF
--- a/lib/slugy.ex
+++ b/lib/slugy.ex
@@ -1,13 +1,61 @@
 defmodule Slugy do
+  @moduledoc ~S"""
+  Slugy is a Phoenix library to generate slugs to ecto schema fields
+
+  Let's suppose we have a Post schema and we want to generate a slug from `title` field
+  and save it to the `slug` field. To achieve that we need to call Slugy.slugify/2
+  following the changeset pipeline passing the desireable field. Slugy.slugify/2 generates
+  the slug and put it to the changeset.
+
+    defmodule Post do
+      import Slugy, only: [slugify: 2]
+
+      schema "posts" do
+        field :title, :string
+        field :body, :text
+        field :published_at, :datetime
+        field :slug, :string
+      end
+
+      def changeset(post, attrs) do
+        post
+        |> cast(attrs, [:title, :body, :published_at])
+        |> slugify(:title)
+      end
+    end
+  """
+  import Ecto.Changeset
+
+  @doc ~S"""
+  Slugy.slugify/2 puts the slug generated on the given changeset and returns the changeset.
+
+  Returns the changeset itself if there are no changes to apply.
+
+  ## Examples
+
+      iex> slugify(changeset, :name)
+      %Ecto.Changeset{changes: %{slug: "a-slug-string-generated-from-name"}}
+
+      iex> slugify(changeset, :name)
+      %Ecto.Changeset{}
+  """
+  def slugify(changeset, key) when is_atom(key) do
+    if string = get_change(changeset, key) do
+      put_change(changeset, :slug, generate_slug(string))
+    else
+      changeset
+    end
+  end
+
   @doc """
   Returns a downcased dashed string.
 
   ## Examples
 
-      iex> Slugy.slugify("Hey ow lets go")
-      "hey-ow-lets-go"
+      iex> generate_slug("Vamo que vamo")
+      "vamo-que-vamo"
   """
-  def slugify(str) do
+  def generate_slug(str) do
     str
     |> String.normalize(:nfd)
     |> String.replace(~r/[^A-z\s\d]/u, "")

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,8 @@ defmodule Slugy.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:ex_doc, ">= 0.0.0", only: :dev}
+      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:ecto, "~> 2.2"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,10 @@
 %{
+  "decimal": {:hex, :decimal, "1.5.0", "b0433a36d0e2430e3d50291b1c65f53c37d56f83665b43d79963684865beab68", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.6", "b6da42b3831458d3ecc57314dff3051b080b9b2be88c2e5aa41cd642a5b044ed", [:mix], [], "hexpm"},
+  "ecto": {:hex, :ecto, "2.2.11", "4bb8f11718b72ba97a2696f65d247a379e739a0ecabf6a13ad1face79844791c", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.5.5", "9e08dfc45280c5684d771ad58159f718a7b5788596099bdfb0284597d368a882", [:mix], [{:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
 }

--- a/test/slugy_test.exs
+++ b/test/slugy_test.exs
@@ -1,9 +1,33 @@
 defmodule SlugyTest do
   use ExUnit.Case
-  doctest Slugy
 
-  test "slugy/1 downcase alphanumerics" do
-    assert Slugy.slugify("Hey ow lets go") == "hey-ow-lets-go"
-    assert Slugy.slugify("Olá, julia") == "ola-julia"
+  alias Ecto.Changeset
+
+  defmodule Post do
+    use Ecto.Schema
+
+    embedded_schema do
+      field(:title, :string)
+      field(:slug, :string)
+    end
+  end
+
+  describe "slugify/2" do
+    test "puts generated slug on changeset changes and returns changeset" do
+      changeset = Changeset.cast(%Post{}, %{title: "A new post"}, [:title])
+
+      assert %{changes: %{slug: "a-new-post"}} = Slugy.slugify(changeset, :title)
+    end
+
+    test "returns changeset when there is no changes to apply" do
+      changeset = Changeset.cast(%Post{}, %{}, [:title])
+
+      assert %{changes: %{}} = Slugy.slugify(changeset, :name)
+    end
+  end
+
+  describe "generate_slug/1" do
+    assert Slugy.generate_slug("Hey ow lets go") == "hey-ow-lets-go"
+    assert Slugy.generate_slug("Olá, julia") == "ola-julia"
   end
 end


### PR DESCRIPTION
* Implemented Slugy.slugify/2 function to use
  on the changeset pipeline of a Phoenix schema module
  to set the slug into the slug field