### PR TITLE
Implements Slug protocol to generate custom slugs

### DIFF
--- a/lib/slugy.ex
+++ b/lib/slugy.ex
@@ -25,6 +25,7 @@ defmodule Slugy do
     end
   """
   import Ecto.Changeset
+  alias Slugy.Slug
 
   @doc ~S"""
   Slugy.slugify/2 puts the slug generated on the given changeset and returns the changeset.
@@ -38,16 +39,7 @@ defmodule Slugy do
 
       iex> slugify(changeset, :name)
       %Ecto.Changeset{}
-  """
-  def slugify(changeset, key) when is_atom(key) do
-    if string = get_change(changeset, key) do
-      put_change(changeset, :slug, generate_slug(string))
-    else
-      changeset
-    end
-  end
 
-  @doc ~S"""
   ## Slugify a field from a embedded struct
 
   In rare cases you need to generate the slug from a field inside another structure.
@@ -60,12 +52,47 @@ defmodule Slugy do
 
       iex> slugify(changeset, [:data, :title])
       %Ecto.Changeset{changes: %{slug: "content-1"}}
+
+  ## Custom slug
+
+  If you want a custom slug composed for more than one fields e.g. a post title and the publication date
+  like so "how-to-use-slugy-2018-10-10" you need to implement the `Slugy.Slug protocol` that extracts
+  the desirable fields to generate the slug
+
+      defimpl Slugy.Slug, for: Post do
+        def to_slug(%{title: title, published_at: published_at}) do
+          "#{title} #{published_at}"
+        end
+      end
+
+  But you still have to use `Slugy.slugify/2` in changeset function like shown
+  on above examples to know whether the field was changed or not.
   """
+  def slugify(changeset, key) when is_atom(key) do
+    if str = get_change(changeset, key) do
+      do_slugify(changeset, str)
+    else
+      changeset
+    end
+  end
+
   def slugify(changeset, nested_field) when is_list(nested_field) do
     with str when not is_nil(str) <- get_in(changeset.changes, nested_field) do
-      put_change(changeset, :slug, generate_slug(str))
+      do_slugify(changeset, str)
     else
       _ -> changeset
+    end
+  end
+
+  defp do_slugify(changeset, str) do
+    struct = Map.merge(changeset.data, changeset.changes)
+
+    if Slug.impl_for(struct) do
+      slug = struct |> Slug.to_slug() |> generate_slug()
+
+      put_change(changeset, :slug, slug)
+    else
+      put_change(changeset, :slug, generate_slug(str))
     end
   end
 
@@ -84,4 +111,37 @@ defmodule Slugy do
     |> String.replace(~r/\s/, "-")
     |> String.downcase()
   end
+end
+
+defprotocol Slugy.Slug do
+  @moduledoc ~S"""
+  A protocol that builds a string to converts into a slug
+
+  This protocol is used by Slugy.slugify/2. For example, when you
+  want a custom slug for a Post, composed by the `title` and the
+  `published_at` fields:
+
+      "how-to-use-slugy-2018-10-10"
+
+  Suppose you have a Post module with the following fields:
+
+      defmodule Post do
+        schema "posts" do
+          field :title, :string
+          field :body, :text
+          field :published_at, :datetime
+        end
+      end
+
+  You need to implement the Slugy.Slug protocol to achieve that:
+
+      defimpl Slugy.Slug, for: Post do
+        def to_slug(%{title: title, published_at: published_at}) do
+          "#{title} #{published_at}"
+        end
+      end
+
+  Slugy internally uses this string to build your custom slug.
+  """
+  def to_slug(struct)
 end

--- a/lib/support.ex
+++ b/lib/support.ex
@@ -1,0 +1,14 @@
+defmodule Slugy.Support.Content do
+  use Ecto.Schema
+
+  embedded_schema do
+    field(:name, :string)
+    field(:type, :string)
+  end
+end
+
+defimpl Slugy.Slug, for: Slugy.Support.Content do
+  def to_slug(%{name: name, type: type}) do
+    "#{name} #{type}"
+  end
+end

--- a/test/slugy_test.exs
+++ b/test/slugy_test.exs
@@ -2,6 +2,7 @@ defmodule SlugyTest do
   use ExUnit.Case
 
   alias Ecto.Changeset
+  alias Slugy.Support.Content
 
   defmodule Post do
     use Ecto.Schema
@@ -41,6 +42,16 @@ defmodule SlugyTest do
 
       assert %{changes: %{slug: "a-new-post"}} =
                Slugy.slugify(changeset, [:data, :title])
+    end
+  end
+
+  describe "slugify/2 in a module that implements Slug protocol" do
+    test "puts custom generated slug on changeset changes and returns changeset" do
+      attrs = %{name: "Processo Penal", type: "video"}
+
+      changeset = Changeset.cast(%Content{}, attrs, [:name, :type])
+
+      assert %{changes: %{slug: "processo-penal-video"}} = Slugy.slugify(changeset, :name)
     end
   end
 


### PR DESCRIPTION
  This protocol is used by Slugy.slugify/2. For example, when you
  want a custom slug for a Post, composed by the `title` and the
  `published_at` fields:

      "how-to-use-slugy-2018-10-10"

  Suppose you have a Post module with the following fields:

      defmodule Post do
        schema "posts" do
          field :title, :string
          field :body, :text
          field :published_at, :datetime
        end
      end

  You need to implement the Slugy.Slug protocol to achieve that:

      defimpl Slugy.Slug, for: Post do
        def to_slug(%{title: title, published_at: published_at}) do
          "#{title} #{published_at}"
        end
      end

  Slugy internally uses this string to build your custom slug.