### PR TITLE
Change Ecto dependency to >= 3.5.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Add to your `mix.exs` file.
 ```elixir
 def deps do
   [
-    {:slugy, "~> 4.1.0"} # compatible with ecto >= 3.5
+    {:slugy, "~> 4.1.1"} # compatible with ecto >= 3.5
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Slugy.MixProject do
     [
       app: :slugy,
       elixir: "~> 1.8",
-      version: "4.1.0",
+      version: "4.1.1",
       start_permanent: Mix.env() == :prod,
       description: "A Phoenix library to generate slug for your schemas",
       elixirc_paths: elixirc_paths(Mix.env()),
@@ -25,7 +25,7 @@ defmodule Slugy.MixProject do
   defp deps do
     [
       {:ex_doc, ">= 0.0.0", only: :dev},
-      {:ecto, "~> 3.5.7"}
+      {:ecto, ">= 3.5.7"}
     ]
   end
 


### PR DESCRIPTION
With this change, slugy doesn't lock Ecto version to 3.5.x, allowing us to use newer versions such as 3.6.x.